### PR TITLE
feat: add extension update frequency visualization

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "Neues Update",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "Update-Aktivität",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "Durchschnitt: $1 Tage zwischen Updates",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "Version",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "Von v$1",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "$1 Tage seit vorherigem",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "New update",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "Update Activity",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "Avg: $1 days between updates",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "Version",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "From v$1",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "$1 days since previous",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "Nueva actualización",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "Actividad de Actualizaciones",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "Promedio: $1 días entre actualizaciones",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "Versión",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "Desde v$1",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "$1 días desde el anterior",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "Nouvelle mise à jour",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "Activité des Mises à Jour",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "Moyenne : $1 jours entre les mises à jour",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "Version",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "Depuis v$1",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "$1 jours depuis le précédent",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "Nuovo aggiornamento",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "Attività degli Aggiornamenti",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "Media: $1 giorni tra gli aggiornamenti",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "Versione",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "Da v$1",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "$1 giorni dal precedente",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "新しい更新",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "更新アクティビティ",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "平均: 更新間隔$1日",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "バージョン",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "v$1から",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "前回から$1日",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "새 업데이트",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "업데이트 활동",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "평균: 업데이트 간격 $1일",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "버전",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "v$1에서",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "이전 업데이트로부터 $1일",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "Nova atualização",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "Atividade de Atualizações",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "Média: $1 dias entre atualizações",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "Versão",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "De v$1",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "$1 dias desde o anterior",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "Новое обновление",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "Активность обновлений",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "В среднем: $1 дней между обновлениями",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "Версия",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "С v$1",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "$1 дней с предыдущего",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -420,5 +420,25 @@
     "options_update_item_new_badge_aria": {
         "message": "新更新",
         "description": "Aria label for new/unread update badge"
+    },
+    "options_timeline_title": {
+        "message": "更新活动",
+        "description": "Title for the update timeline visualization"
+    },
+    "options_timeline_avg_days": {
+        "message": "平均：更新间隔$1天",
+        "description": "Shows average days between updates in timeline"
+    },
+    "options_timeline_version": {
+        "message": "版本",
+        "description": "Version label for timeline tooltip accessibility"
+    },
+    "options_timeline_from_version": {
+        "message": "从 v$1",
+        "description": "Shows previous version in timeline tooltip"
+    },
+    "options_timeline_days_gap": {
+        "message": "距上次更新$1天",
+        "description": "Shows days since previous update in timeline tooltip"
     }
 }

--- a/src/options/components/ExtensionCard.tsx
+++ b/src/options/components/ExtensionCard.tsx
@@ -7,6 +7,7 @@ import { useRootStore } from '../stores/root-store';
 
 import { FallbackIcon } from './FallbackIcon';
 import { UpdateItem } from './UpdateItem';
+import { UpdateTimeline } from './UpdateTimeline';
 
 interface ExtensionCardProps {
     extensionId: string;
@@ -155,6 +156,9 @@ export const ExtensionCard: React.FC<ExtensionCardProps> = observer(({ extension
 
             {isExpanded && (
                 <>
+                    {/* Update Timeline Visualization */}
+                    {updates.length > 1 && <UpdateTimeline updates={updates} />}
+
                     <ul className="extension-updates">
                         {visibleUpdates.map((update) => (
                             <UpdateItem

--- a/src/options/components/UpdateTimeline.tsx
+++ b/src/options/components/UpdateTimeline.tsx
@@ -1,0 +1,295 @@
+import React, { useMemo, useState } from 'react';
+
+import { ExtensionUpdate } from '../../common/update-storage';
+import { t } from '../../common/utils/i18n';
+
+interface UpdateTimelineProps {
+    updates: ExtensionUpdate[];
+}
+
+interface TimelinePoint {
+    date: Date;
+    version: string;
+    previousVersion?: string;
+    daysSincePrevious: number | null;
+    position: number; // 0-100 percentage position on timeline
+}
+
+interface TimelineMetrics {
+    averageDaysBetweenUpdates: number | null;
+    totalUpdates: number;
+    timeSpanDays: number;
+    oldestUpdate: Date | null;
+    newestUpdate: Date | null;
+}
+
+/**
+ * Calculates timeline data points from extension updates
+ */
+function calculateTimelineData(updates: ExtensionUpdate[]): {
+    points: TimelinePoint[];
+    metrics: TimelineMetrics;
+} {
+    if (updates.length === 0) {
+        return {
+            points: [],
+            metrics: {
+                averageDaysBetweenUpdates: null,
+                totalUpdates: 0,
+                timeSpanDays: 0,
+                oldestUpdate: null,
+                newestUpdate: null,
+            },
+        };
+    }
+
+    // Sort updates by date (oldest first for timeline)
+    const sortedUpdates = [...updates].sort((a, b) => {
+        return new Date(a.updateDate).getTime() - new Date(b.updateDate).getTime();
+    });
+
+    const dates = sortedUpdates.map((u) => new Date(u.updateDate));
+    const oldestUpdate = dates[0];
+    const newestUpdate = dates[dates.length - 1];
+
+    // Calculate time span - use at least 30 days for better visualization
+    const actualTimeSpanMs = newestUpdate.getTime() - oldestUpdate.getTime();
+    const minTimeSpanMs = 30 * 24 * 60 * 60 * 1000; // 30 days minimum
+    const timeSpanMs = Math.max(actualTimeSpanMs, minTimeSpanMs);
+    const timeSpanDays = Math.ceil(timeSpanMs / (24 * 60 * 60 * 1000));
+
+    // Calculate points with positions and gaps
+    const points: TimelinePoint[] = sortedUpdates.map((update, index) => {
+        const date = new Date(update.updateDate);
+
+        // Calculate days since previous update
+        let daysSincePrevious: number | null = null;
+        if (index > 0) {
+            const previousDate = dates[index - 1];
+            daysSincePrevious = Math.round(
+                (date.getTime() - previousDate.getTime()) / (24 * 60 * 60 * 1000),
+            );
+        }
+
+        // Calculate position as percentage (0-100)
+        // If only one update, center it
+        let position: number;
+        if (updates.length === 1) {
+            position = 50;
+        } else {
+            position = ((date.getTime() - oldestUpdate.getTime()) / timeSpanMs) * 100;
+            // Ensure first and last points have some padding
+            position = Math.max(5, Math.min(95, position));
+        }
+
+        return {
+            date,
+            version: update.version,
+            previousVersion: update.previousVersion,
+            daysSincePrevious,
+            position,
+        };
+    });
+
+    // Calculate average days between updates
+    let averageDaysBetweenUpdates: number | null = null;
+    if (points.length > 1) {
+        const gaps = points
+            .map((p) => p.daysSincePrevious)
+            .filter((d): d is number => d !== null);
+        if (gaps.length > 0) {
+            averageDaysBetweenUpdates = Math.round(
+                gaps.reduce((sum, d) => sum + d, 0) / gaps.length,
+            );
+        }
+    }
+
+    return {
+        points,
+        metrics: {
+            averageDaysBetweenUpdates,
+            totalUpdates: updates.length,
+            timeSpanDays,
+            oldestUpdate,
+            newestUpdate,
+        },
+    };
+}
+
+/**
+ * Formats a date for display
+ */
+function formatDate(date: Date): string {
+    return date.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+    });
+}
+
+/**
+ * Returns a color based on update frequency (days since previous)
+ * Green = frequent updates, Yellow = moderate, Red = long gaps
+ */
+function getGapColor(daysSincePrevious: number | null): string {
+    if (daysSincePrevious === null) {
+        return '#6c757d'; // Gray for first update
+    }
+    if (daysSincePrevious <= 30) {
+        return '#198754'; // Green - very active
+    }
+    if (daysSincePrevious <= 90) {
+        return '#0d6efd'; // Blue - active
+    }
+    if (daysSincePrevious <= 180) {
+        return '#ffc107'; // Yellow - moderate
+    }
+    return '#dc3545'; // Red - long gap
+}
+
+/**
+ * UpdateTimeline component displays a visual timeline of extension updates
+ * showing when updates occurred and the gaps between them.
+ */
+export function UpdateTimeline({ updates }: UpdateTimelineProps): React.ReactNode {
+    const [hoveredPoint, setHoveredPoint] = useState<TimelinePoint | null>(null);
+    const [tooltipPosition, setTooltipPosition] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+    const { points, metrics } = useMemo(() => calculateTimelineData(updates), [updates]);
+
+    // Don't render if no updates
+    if (points.length === 0) {
+        return null;
+    }
+
+    const handleMouseEnter = (point: TimelinePoint, event: React.MouseEvent) => {
+        const rect = event.currentTarget.getBoundingClientRect();
+        setHoveredPoint(point);
+        setTooltipPosition({
+            x: rect.left + rect.width / 2,
+            y: rect.top,
+        });
+    };
+
+    const handleMouseLeave = () => {
+        setHoveredPoint(null);
+    };
+
+    return (
+        <div className="update-timeline">
+            <div className="timeline-header">
+                <span className="timeline-title">{t('options_timeline_title')}</span>
+                {metrics.averageDaysBetweenUpdates !== null && (
+                    <span className="timeline-metric">
+                        {t('options_timeline_avg_days', metrics.averageDaysBetweenUpdates.toString())}
+                    </span>
+                )}
+            </div>
+
+            <div className="timeline-container">
+                {/* Timeline track */}
+                <div className="timeline-track">
+                    {/* Timeline points */}
+                    {points.map((point, index) => (
+                        <div
+                            key={`${point.version}-${point.date.getTime()}`}
+                            className="timeline-point-wrapper"
+                            style={{ left: `${point.position}%` }}
+                            onMouseEnter={(e) => handleMouseEnter(point, e)}
+                            onMouseLeave={handleMouseLeave}
+                            onFocus={(e) => handleMouseEnter(point, e as unknown as React.MouseEvent)}
+                            onBlur={handleMouseLeave}
+                            tabIndex={0}
+                            role="button"
+                            aria-label={`${t('options_timeline_version')} ${point.version}, ${formatDate(point.date)}`}
+                        >
+                            <div
+                                className="timeline-point"
+                                style={{ backgroundColor: getGapColor(point.daysSincePrevious) }}
+                            />
+                            {/* Gap indicator line to previous point */}
+                            {index > 0 && (
+                                <div
+                                    className="timeline-gap-line"
+                                    style={{
+                                        width: `${point.position - points[index - 1].position}%`,
+                                        left: `${points[index - 1].position - point.position}%`,
+                                        backgroundColor: getGapColor(point.daysSincePrevious),
+                                        opacity: 0.3,
+                                    }}
+                                />
+                            )}
+                        </div>
+                    ))}
+                </div>
+
+                {/* Time labels */}
+                <div className="timeline-labels">
+                    {metrics.oldestUpdate && (
+                        <span className="timeline-label timeline-label-start">
+                            {formatDate(metrics.oldestUpdate)}
+                        </span>
+                    )}
+                    {metrics.newestUpdate && metrics.oldestUpdate
+                        && metrics.newestUpdate.getTime() !== metrics.oldestUpdate.getTime() && (
+                        <span className="timeline-label timeline-label-end">
+                            {formatDate(metrics.newestUpdate)}
+                        </span>
+                    )}
+                </div>
+            </div>
+
+            {/* Tooltip */}
+            {hoveredPoint && (
+                <div
+                    className="timeline-tooltip"
+                    style={{
+                        position: 'fixed',
+                        left: tooltipPosition.x,
+                        top: tooltipPosition.y - 10,
+                        transform: 'translate(-50%, -100%)',
+                    }}
+                >
+                    <div className="tooltip-version">
+                        v
+                        {hoveredPoint.version}
+                    </div>
+                    <div className="tooltip-date">{formatDate(hoveredPoint.date)}</div>
+                    {hoveredPoint.previousVersion && (
+                        <div className="tooltip-previous">
+                            {t('options_timeline_from_version', hoveredPoint.previousVersion)}
+                        </div>
+                    )}
+                    {hoveredPoint.daysSincePrevious !== null && (
+                        <div
+                            className="tooltip-gap"
+                            style={{ color: getGapColor(hoveredPoint.daysSincePrevious) }}
+                        >
+                            {t('options_timeline_days_gap', hoveredPoint.daysSincePrevious.toString())}
+                        </div>
+                    )}
+                </div>
+            )}
+
+            {/* Legend */}
+            <div className="timeline-legend">
+                <div className="legend-item">
+                    <span className="legend-dot" style={{ backgroundColor: '#198754' }} />
+                    <span className="legend-text">&lt;30d</span>
+                </div>
+                <div className="legend-item">
+                    <span className="legend-dot" style={{ backgroundColor: '#0d6efd' }} />
+                    <span className="legend-text">30-90d</span>
+                </div>
+                <div className="legend-item">
+                    <span className="legend-dot" style={{ backgroundColor: '#ffc107' }} />
+                    <span className="legend-text">90-180d</span>
+                </div>
+                <div className="legend-item">
+                    <span className="legend-dot" style={{ backgroundColor: '#dc3545' }} />
+                    <span className="legend-text">&gt;180d</span>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/options/styles.css
+++ b/src/options/styles.css
@@ -383,3 +383,151 @@ h1 {
 .modal-footer .btn {
     min-width: 80px;
 }
+
+/* Update Timeline Styles */
+.update-timeline {
+    padding: 12px 15px;
+    background-color: #f8f9fa;
+    border-top: 1px solid #e9ecef;
+}
+
+.timeline-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.timeline-title {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #495057;
+}
+
+.timeline-metric {
+    font-size: 0.75rem;
+    color: #6c757d;
+    background-color: #e9ecef;
+    padding: 2px 8px;
+    border-radius: 12px;
+}
+
+.timeline-container {
+    position: relative;
+    margin-bottom: 8px;
+}
+
+.timeline-track {
+    position: relative;
+    height: 24px;
+    background: linear-gradient(to right, #e9ecef, #dee2e6);
+    border-radius: 12px;
+    margin: 0 10px;
+}
+
+.timeline-point-wrapper {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 2;
+    cursor: pointer;
+}
+
+.timeline-point-wrapper:focus {
+    outline: 2px solid #0d6efd;
+    outline-offset: 2px;
+    border-radius: 50%;
+}
+
+.timeline-point {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid white;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.timeline-point-wrapper:hover .timeline-point {
+    transform: scale(1.3);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.timeline-gap-line {
+    position: absolute;
+    height: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+    border-radius: 2px;
+    z-index: 1;
+}
+
+.timeline-labels {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 6px;
+    padding: 0 10px;
+}
+
+.timeline-label {
+    font-size: 0.7rem;
+    color: #6c757d;
+}
+
+.timeline-tooltip {
+    background: #212529;
+    color: white;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    z-index: 1000;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    pointer-events: none;
+    white-space: nowrap;
+}
+
+.tooltip-version {
+    font-weight: 600;
+    font-size: 0.9rem;
+    margin-bottom: 2px;
+}
+
+.tooltip-date {
+    color: #adb5bd;
+    margin-bottom: 4px;
+}
+
+.tooltip-previous {
+    font-size: 0.75rem;
+    color: #adb5bd;
+}
+
+.tooltip-gap {
+    font-size: 0.75rem;
+    font-weight: 500;
+    margin-top: 4px;
+}
+
+.timeline-legend {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.legend-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+}
+
+.legend-text {
+    font-size: 0.65rem;
+    color: #6c757d;
+}


### PR DESCRIPTION
Show users how active/maintained an extension is by displaying:
- Visual timeline of detected updates
- Color-coded update frequency gaps • Green: frequent updates (<30 days) • Blue: regular updates (30-90 days) • Yellow: moderate activity (90-180 days) • Red: long gaps, potentially abandoned (>180 days)
- Average days between updates metric
- Interactive tooltips with exact dates and version transitions

Helps users quickly identify if an extension is well-maintained or abandoned.

Closes #2