### PR TITLE
ci: automated Chrome Web Store deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Lint, test, and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
+      - name: Lint and type-check
+        run: pnpm lint
+      - name: Unit tests
+        run: pnpm test
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+      - name: End-to-end tests
+        # The e2e suite loads the unpacked extension, which requires a headed
+        # Chromium; xvfb provides the virtual display on the Linux runner.
+        run: xvfb-run -a pnpm test:e2e
+      - name: Build release bundle
+        run: pnpm release

--- a/.github/workflows/deploy-chrome-store.yml
+++ b/.github/workflows/deploy-chrome-store.yml
@@ -1,0 +1,203 @@
+name: Deploy Chrome Web Store
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Published release tag to deploy (vX.Y.Z)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Upload and submit for review
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    runs-on: ubuntu-latest
+    concurrency:
+      group: chrome-store-deploy
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GO_WEBEXT_VERSION: v0.4.2
+    steps:
+      - name: Resolve and validate release
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            RELEASE_TAG="$INPUT_TAG"
+            if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Release tag must match vX.Y.Z: $RELEASE_TAG" >&2
+              exit 1
+            fi
+          else
+            RELEASE_TAG="$EVENT_TAG"
+            if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::notice::Release tag $RELEASE_TAG does not match" \
+                "vX.Y.Z; skipping store deployment."
+              echo "deploy=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          RELEASE_JSON="$(gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" --json isDraft,isPrerelease)"
+          if [[ "$(jq -r '.isDraft' <<<"$RELEASE_JSON")" != "false" ]]; then
+            echo "Release $RELEASE_TAG is a draft;" \
+              "publish it before deploying to the store" >&2
+            exit 1
+          fi
+          if [[ "$(jq -r '.isPrerelease' <<<"$RELEASE_JSON")" != "false" ]]; then
+            echo "Release $RELEASE_TAG is a pre-release;" \
+              "store deployment ships full releases only" >&2
+            exit 1
+          fi
+
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Check store configuration
+        if: steps.release.outputs.deploy == 'true'
+        env:
+          CHROME_APP_ID: ${{ vars.CHROME_APP_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in CHROME_APP_ID CHROME_CLIENT_ID CHROME_CLIENT_SECRET \
+            CHROME_REFRESH_TOKEN CHROME_PUBLISHER_ID; do
+            [[ -n "${!name}" ]] || missing+=("$name")
+          done
+          if [[ "${#missing[@]}" -gt 0 ]]; then
+            echo "Missing store configuration: ${missing[*]}" >&2
+            echo "Set the CHROME_APP_ID repository variable and the secrets" \
+              "listed in docs/RELEASE.md before deploying." >&2
+            exit 1
+          fi
+
+      - name: Download release assets
+        if: steps.release.outputs.deploy == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern chrome.zip \
+            --pattern SHA256SUMS \
+            --dir release-assets
+
+      - name: Verify asset integrity and version
+        if: steps.release.outputs.deploy == 'true'
+        working-directory: release-assets
+        env:
+          PACKAGE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          grep ' chrome\.zip$' SHA256SUMS | sha256sum --check --strict -
+          ZIP_VERSION="$(unzip -p chrome.zip manifest.json | jq -r '.version')"
+          if [[ "$ZIP_VERSION" != "$PACKAGE_VERSION" ]]; then
+            echo "chrome.zip manifest version $ZIP_VERSION does not match" \
+              "release version $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Set up Go
+        if: steps.release.outputs.deploy == 'true'
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.26.x'
+          cache: false
+
+      - name: Install go-webext
+        if: steps.release.outputs.deploy == 'true'
+        run: |
+          set -euo pipefail
+          go install "github.com/adguardteam/go-webext@${GO_WEBEXT_VERSION}"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Upload to Chrome Web Store
+        if: steps.release.outputs.deploy == 'true'
+        env:
+          CHROME_API_VERSION: v2
+          CHROME_APP_ID: ${{ vars.CHROME_APP_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          go-webext update chrome \
+            -a "$CHROME_APP_ID" -f release-assets/chrome.zip 2>&1 \
+            | tee "$RUNNER_TEMP/upload-output.txt"
+          # The v2 upload can finish asynchronously; never submit for review
+          # unless the store confirmed this exact version as the draft.
+          if ! grep -qxF "Upload State: SUCCEEDED" \
+            "$RUNNER_TEMP/upload-output.txt"; then
+            echo "Upload did not reach the SUCCEEDED state; refusing to" \
+              "submit an unconfirmed draft for review. Re-run this workflow" \
+              "once the store finishes processing: re-uploading the same" \
+              "version replaces the unsubmitted draft." >&2
+            exit 1
+          fi
+          if ! grep -qxF "Version: $PACKAGE_VERSION" \
+            "$RUNNER_TEMP/upload-output.txt"; then
+            echo "Store draft version does not match release version" \
+              "$PACKAGE_VERSION; refusing to submit for review." >&2
+            exit 1
+          fi
+
+      - name: Submit for review with deferred publishing
+        if: steps.release.outputs.deploy == 'true'
+        env:
+          CHROME_API_VERSION: v2
+          CHROME_APP_ID: ${{ vars.CHROME_APP_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+        run: |
+          set -euo pipefail
+          go-webext publish chrome -a "$CHROME_APP_ID" --staged 2>&1
+
+      - name: Report store status
+        if: steps.release.outputs.deploy == 'true'
+        env:
+          CHROME_API_VERSION: v2
+          CHROME_APP_ID: ${{ vars.CHROME_APP_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          go-webext status chrome -a "$CHROME_APP_ID" 2>&1 \
+            | tee "$RUNNER_TEMP/status-output.txt"
+          {
+            echo "## Chrome Web Store deployment"
+            echo
+            echo "- Release: \`$RELEASE_TAG\` (version $PACKAGE_VERSION)"
+            echo "- Submitted for review with deferred publishing (staged)."
+            echo "- After approval, publish manually in the Chrome Web Store" \
+              "Developer Dashboard within 30 days."
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/status-output.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,141 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release:
+    name: Validate release context
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ctx.outputs.version }}
+      tag: ${{ steps.ctx.outputs.tag }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Resolve and validate release
+        id: ctx
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          # The git tag is the source of truth for the released version.
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            RELEASE_TAG="${RELEASE_REF#refs/tags/}"
+            if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Release tag must match vX.Y.Z: $RELEASE_TAG" >&2
+              exit 1
+            fi
+            VERSION="${RELEASE_TAG#v}"
+            git fetch origin master
+            TAG_COMMIT="$(git rev-parse "$RELEASE_TAG^{commit}")"
+            if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/master; then
+              echo "Tagged commit must be reachable from master" >&2
+              exit 1
+            fi
+          else
+            # Manual dispatch has no tag: build a dry run from package.json.
+            VERSION="$(node -p "require('./package.json').version")"
+            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "package.json version is not semantic: $VERSION" >&2
+              exit 1
+            fi
+            RELEASE_TAG="v$VERSION"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+  build-extension:
+    name: Build store archive
+    needs: validate-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
+      - name: Stamp version from the release tag
+        env:
+          VERSION: ${{ needs.validate-release.outputs.version }}
+        run: npm pkg set version="$VERSION"
+      - name: Build release bundle
+        run: pnpm release
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+      - name: End-to-end tests
+        run: xvfb-run -a pnpm test:e2e
+      - name: Verify manifest version and write checksums
+        working-directory: dist/release
+        env:
+          VERSION: ${{ needs.validate-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          ZIP_VERSION="$(unzip -p chrome.zip manifest.json | jq -r '.version')"
+          if [[ "$ZIP_VERSION" != "$VERSION" ]]; then
+            echo "chrome.zip manifest version $ZIP_VERSION does not match" \
+              "release version $VERSION" >&2
+            exit 1
+          fi
+          sha256sum chrome.zip > SHA256SUMS
+          sha256sum -c SHA256SUMS
+      - name: Retain store-ready archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: extensions-update-tracker-${{ needs.validate-release.outputs.version }}
+          path: |
+            dist/release/chrome.zip
+            dist/release/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 30
+
+  draft-release:
+    name: Create draft GitHub release
+    if: github.event_name == 'push'
+    needs: [validate-release, build-extension]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ needs.validate-release.outputs.tag }}
+      PACKAGE_VERSION: ${{ needs.validate-release.outputs.version }}
+    steps:
+      - name: Download store archive
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: extensions-update-tracker-${{ needs.validate-release.outputs.version }}
+          path: release-assets
+      - name: Verify checksums
+        working-directory: release-assets
+        run: sha256sum -c SHA256SUMS
+      - name: Refuse to replace an existing release
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists" >&2
+            exit 1
+          fi
+      - name: Create draft release
+        run: |
+          set -euo pipefail
+          gh release create "$RELEASE_TAG" release-assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft \
+            --verify-tag \
+            --title "Extensions Update Tracker $PACKAGE_VERSION" \
+            --notes "Store-ready Chrome extension archive for Extensions Update Tracker $PACKAGE_VERSION. Publishing this release submits the build to the Chrome Web Store for review (staged publishing)."

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
   - Show permission diff in update history UI
   - Alert users to significant permission changes (security feature)
 - [ ] Increase the number of locales to 40
-- [ ] Set up deployment to Chrome Web Store via GitHub Actions
+- [x] Set up deployment to Chrome Web Store via GitHub Actions (done in 1.3.0 — see docs/RELEASE.md)
 - [ ] Publish to Microsoft Edge Add-ons and set up deployment via GitHub Actions
 - [ ] Publish to Firefox Add-ons and set up deployment via GitHub Actions
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,68 @@
+# Releasing to the Chrome Web Store
+
+Publishing is automated with GitHub Actions and AdGuard's
+[`go-webext`](https://github.com/adguardteam/go-webext) CLI. Nothing goes live
+automatically — a build is submitted to the store for review with **staged
+(deferred) publishing**, and the final "publish" click stays manual.
+
+## How a release flows
+
+1. **Tag** a commit on `master`: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+   The **git tag is the source of truth** for the version — CI stamps it into
+   the manifest at build time, so you do **not** need to bump `package.json`
+   for a release (the `version` field there is only a local-dev marker).
+2. **`release.yml`** builds the Chrome bundle, runs the e2e suite, and creates
+   a **draft** GitHub Release with `chrome.zip` + `SHA256SUMS`.
+3. **Publish the draft Release** in the GitHub UI once you're happy with it.
+4. Publishing the Release triggers **`deploy-chrome-store.yml`**, which uploads
+   `chrome.zip` to the Chrome Web Store and submits it for review (staged).
+5. After the store approves it (email), **publish the approved version manually**
+   in the [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)
+   within ~30 days (an approved staged submission otherwise reverts to a draft).
+
+`workflow_dispatch` fallbacks exist on both workflows: `release.yml` can be run
+manually as a build dry run, and `deploy-chrome-store.yml` accepts a `tag` input
+to re-deploy an already-published Release.
+
+## One-time repository setup
+
+The workflows need one repository **variable** and four **secrets**
+(Settings → Secrets and variables → Actions):
+
+| Name | Kind | Value |
+| --- | --- | --- |
+| `CHROME_APP_ID` | variable | `cdgepknigaiclfdmjckaknepgcighbnh` (this extension's store ID) |
+| `CHROME_CLIENT_ID` | secret | Google OAuth client ID |
+| `CHROME_CLIENT_SECRET` | secret | Google OAuth client secret |
+| `CHROME_REFRESH_TOKEN` | secret | OAuth refresh token |
+| `CHROME_PUBLISHER_ID` | secret | Chrome Web Store publisher ID |
+
+The four secrets are **per-Google-publisher-account**, not per-extension. If
+this extension lives under the same publisher account as another project that
+already has them (e.g. `kode-injector`), reuse the existing values verbatim —
+only `CHROME_APP_ID` is specific to this extension. For example, reusing an
+existing local `.env`:
+
+```bash
+set -a; source /path/to/other-project/.env; set +a
+REPO=maximtop/extensions-update-tracker
+gh secret   set CHROME_CLIENT_ID     --repo "$REPO" --body "$CHROME_CLIENT_ID"
+gh secret   set CHROME_CLIENT_SECRET --repo "$REPO" --body "$CHROME_CLIENT_SECRET"
+gh secret   set CHROME_REFRESH_TOKEN --repo "$REPO" --body "$CHROME_REFRESH_TOKEN"
+gh secret   set CHROME_PUBLISHER_ID  --repo "$REPO" --body "$CHROME_PUBLISHER_ID"
+gh variable set CHROME_APP_ID        --repo "$REPO" --body "cdgepknigaiclfdmjckaknepgcighbnh"
+```
+
+To mint fresh credentials instead: create a Web-application OAuth client
+(redirect URI `https://developers.google.com/oauthplayground`, scope
+`https://www.googleapis.com/auth/chromewebstore`, consent screen "In
+production"), then exchange an authorization code for a refresh token via the
+OAuth Playground.
+
+## Related workflows
+
+- **`ci.yml`** — lint, unit tests, e2e, and a release build on every push to
+  `master` and every pull request.
+- **`release.yml`** — build + draft GitHub Release on `vX.Y.Z` tags.
+- **`deploy-chrome-store.yml`** — upload + staged submit when a Release is
+  published.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "license": "MIT",
   "version": "1.3.0",
+  "packageManager": "pnpm@10.33.4",
   "author": {
     "name": "Maxim Topciu",
     "email": "me@maximtop.dev"


### PR DESCRIPTION
## Summary

Adds automated Chrome Web Store publishing via GitHub Actions, mirroring the `kode-injector` setup (AdGuard's `go-webext` CLI), trimmed for this Chrome-only extension. Closes the `TODO.md` item.

Three workflows:

- **`ci.yml`** — lint (`eslint` + `tsc`), unit tests, e2e (headed Chromium under `xvfb`), and a release build, on push to `master` and on PRs.
- **`release.yml`** — on a `vX.Y.Z` tag: validate the tag (format + reachable from `master`), **stamp the version from the tag** into the manifest (`npm pkg set version`), build, run e2e, and create a **draft** GitHub Release with `chrome.zip` + `SHA256SUMS`.
- **`deploy-chrome-store.yml`** — near-verbatim copy of kode-injector's: when the Release is **published**, verify the archive, then `go-webext update` + `go-webext publish --staged`. Nothing goes live automatically — it submits for review with deferred publishing; the final publish stays manual.

## Version handling

The **git tag is the source of truth**. CI stamps `${TAG#v}` into the manifest at build time, so releasing is just `git tag vX.Y.Z && git push --tags` from `master` — no manual `package.json` bump. The `version` field stays as a local-dev marker.

## Release flow

`git tag vX.Y.Z && git push origin vX.Y.Z` → draft Release built → **publish the draft** → store submission (staged) → **publish manually** in the CWS Developer Dashboard after approval. Documented in `docs/RELEASE.md`.

## Required before the first real release (repo Settings → Secrets and variables → Actions)

- Variable `CHROME_APP_ID` = `cdgepknigaiclfdmjckaknepgcighbnh` — **already set**.
- Secrets `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`, `CHROME_PUBLISHER_ID` — reuse the existing per-account values (see `docs/RELEASE.md`); **still to be set by the maintainer**.

## Verification

- Tag-driven stamping confirmed locally: `npm pkg set version=9.9.9 && pnpm release` → `chrome.zip` manifest reports `9.9.9`.
- `chrome.zip` has `manifest.json` at the archive root (store-ready).
- `actionlint` passes on all three workflows.
- `ci.yml` runs on this PR — see checks below (validates the `xvfb` e2e path).